### PR TITLE
Revert "need numpy >= 2.3 to allow NPY_2_3_API_VERSION I guess"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "cmeel"
 requires = [
   "cmeel[build]",
-  "numpy>=2.3",
+  "numpy>=2.0",
 ]
 
 [project]


### PR DESCRIPTION
This reverts commit 6c5f968a8d35b479a30c497e1a39f53c2c477058 because that was dumb.